### PR TITLE
Quick styling fixes

### DIFF
--- a/webform/public/stylesheets/style.css
+++ b/webform/public/stylesheets/style.css
@@ -1,5 +1,5 @@
 body {
-  padding: 50px;
+  padding: 16px;
   font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
 }
 

--- a/webform/views/layout.hbs
+++ b/webform/views/layout.hbs
@@ -9,7 +9,8 @@
     <link rel='stylesheet' href='/stylesheets/style.css' />
 
     <!-- Bootstrap -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/css/bootstrap.min.css" integrity="sha512-oc9+XSs1H243/FRN9Rw62Fn8EtxjEYWHXRvjS43YtueEewbS6ObfXcJNyohjHqVKFPoXXUxwc+q1K7Dee6vv9g==" crossorigin="anonymous" />
+    <link rel="stylesheet" media="(prefers-color-scheme: dark)" href="https://stackpath.bootstrapcdn.com/bootswatch/4.5.2/darkly/bootstrap.min.css" integrity="sha384-nNK9n28pDUDDgIiIqZ/MiyO3F4/9vsMtReZK39klb/MtkZI3/LtjSjlmyVPS3KdN" crossorigin="anonymous" />
+    <link rel="stylesheet" media="(prefers-color-scheme: no-preference, prefers-color-scheme: light)" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/css/bootstrap.min.css" integrity="sha512-oc9+XSs1H243/FRN9Rw62Fn8EtxjEYWHXRvjS43YtueEewbS6ObfXcJNyohjHqVKFPoXXUxwc+q1K7Dee6vv9g==" crossorigin="anonymous" />
   </head>
   <body>
     {{{body}}}

--- a/webform/views/layout.hbs
+++ b/webform/views/layout.hbs
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{title}}</title>
-<!--     <link rel='stylesheet' href='/stylesheets/style.css' /> -->
+    <link rel='stylesheet' href='/stylesheets/style.css' />
 
     <!-- Bootstrap -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/css/bootstrap.min.css" integrity="sha512-oc9+XSs1H243/FRN9Rw62Fn8EtxjEYWHXRvjS43YtueEewbS6ObfXcJNyohjHqVKFPoXXUxwc+q1K7Dee6vv9g==" crossorigin="anonymous" />


### PR DESCRIPTION
When developing locally, anything past the first view starts using the actual hosted resources so I was unable to verify this works on anything other than the landing page. Would probably need to look for a dev environment flag and change the routing logic to circumvent this. Unless you guys already have something set up for this and it's just not in the readme.

I was unable to get the docker-compose running fully as I have no idea what should be listed under the oauth secret. I believe I got the other variables set properly though.

At any rate, this PR simply reintroduces padding (please god you need padding) but with a more conventional px size than 50. Additionally, it sets the styling up to respect the user's specified theme preference. You can, of course, swap out the dark theme I chose with any of your chosing.

I went with this free theme from bootswatch since you were already using bootstrap:
https://bootswatch.com/darkly/

![image](https://user-images.githubusercontent.com/11801126/111049672-9a248480-841b-11eb-85e6-9b0dfe82634e.png)
